### PR TITLE
Add Phala Network Serverless Computing Provider w/ template

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ It’s a standard for creating interactive and authenticated experiences - Creat
 - [Web3 Bio](https://api.web3.bio/)
 - [Guide: Onchain Tx Confirmations using OnceUpon API](https://onceupon.notion.site/Public-How-to-use-tx-confirmations-in-your-Frame-w-Once-Upon-862883e5e15a49d5bc5005df69dc627f)
 
+### Serverless Computing Providers
+- [Phala Network](https://phala.network)
+  - [FrameHub Template](https://github.com/Phala-Network/framehub-template)
+
 ### Boilerplate repos
 
 - [Frames.js starter](https://github.com/framesjs/frames.js/tree/main/examples/framesjs-starter)


### PR DESCRIPTION
## Description
Add a section for Serverless Computing Providers in Awesome Frames repo. This can help bring attention to Web3 native solutions and avoid dependencies on centralized providers. Here I added Phala Network and the FrameHub Template to help developers deploy Frames with no dependencies with a minimal solution to deploy Frames on.

Since FrameHub template uses IPFS, ather idea could be adding Storage Providers section like Arweave, Filecoin, etc.