### PR TITLE
docs: add new link to Lil Nouns Frames to the `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ It’s a standard for creating interactive and authenticated experiences - Creat
 - [Mint GPT](https://github.com/instanetk/mintgpt/blob/629e94a47ac51f1110fa5914bd11c12e6bf1f699/src/pageComponents/mint/ContractDemo.tsx#L4)
 - [Bag app](https://github.com/Destiner/bag-app)
 - [in-frame captcha](https://github.com/limone-eth/farcaster-horizon-airstack/tree/main/app/api/captcha)
+- [Lil Nouns Frames](https://github.com/lilnouns/lilnouns-frames)
 
 ### Custom GPTs
 


### PR DESCRIPTION
Lil Nouns Frames is a collection of Farcaster Frames that utilize Lil Nouns resources.