### PR TITLE
Added ComposeCast.xyz as an option to Useful Tools & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Open Frames is a standard for Frames that work across ecosystems
 - [Deploy your frame on-chain using the Internet Computer (ICP](https://medium.com/dfinity/how-to-create-an-on-chain-farcaster-frame-ee232e807219)
 - [Pinata Node.js Frame Development Kit](https://github.com/PinataCloud/pinata-fdk)
 - [framelib, build frames with python and flask](https://github.com/devinaconley/python-frames)
+- [ComposeCastxyz: privacy preserving cast composing gateway](https://github.com/0xSemicolon/composecastxyz)
 
 ### Data & API Providers
 


### PR DESCRIPTION
I think this is the only category that this would fit into. ComposeCast.xyz is a forever free MIT licensed gateway app. It helps frame devs by removing the complexity of needing to figure out what client the user came from (at the moment everyone just links off to https://warpcast.com/~/compose), giving power back to the users of the frames.