### PR TITLE
Add nounspace to apps that support frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ and many more
 - [Launchcaster](https://launchcaster.xyz)
 - [Buttrfly](https://buttrfly.app/)
 - [Hey](https://hey.xyz/)
+- [nounspace, customizable client where you can embed frames](https://nounspace.com)
 
 ## Frame Games
 - [HyperLoot: Dungeon War Season 1](https://warpcast.com/tandavas/0xa86ead6d)


### PR DESCRIPTION
the Frame fidget on nounspace, powered by frames.js, enables embedding any frame on your homebase (private/personal space) or space (public farcaster profile). no more digging for frames in your bookmarks!